### PR TITLE
Fix overriding of SelectedItem in OnApplyTemplate

### DIFF
--- a/WpfControls/WpfControls.CS/Editors/AutoCompleteTextBox.cs
+++ b/WpfControls/WpfControls.CS/Editors/AutoCompleteTextBox.cs
@@ -292,9 +292,11 @@ namespace WpfControls.Editors
                 Editor.PreviewKeyDown += OnEditorKeyDown;
                 Editor.LostFocus += OnEditorLostFocus;
 
-                if (SelectedItem != null)
+                if (SelectedItem != null) 
                 {
+                    _isUpdatingText = true;
                     Editor.Text = BindingEvaluator.Evaluate(SelectedItem);
+                    _isUpdatingText = false;
                 }
 
             }


### PR DESCRIPTION
In `OnApplyTemplate`, if `SelectedItem` is set, updating `Editor.Text` would cause `OnEditorTextChanged` to override the `SelectedItem` to `null`.

This change uses `_isUpdatingText` to suppress this.