### PR TITLE
Changed build action for resources to enable default style

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/AutoCompleteTextBox.csproj
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/AutoCompleteTextBox.csproj
@@ -14,11 +14,19 @@
     <PackageReleaseNotes>Fixes</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Editors\Themes\Generic.xaml" />
+    <None Remove="Themes\Generic.xaml" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase">
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\WindowsBase.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="Editors\Themes\Generic.xaml" />
+    <Page Include="Themes\Generic.xaml" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The "Build Action" for the resources was set to "None". The original source code had the "Build Action" as "Page". This enables the default style of `AutoCompleteTextBox` so you are not required to use a custom style.