### PR TITLE
Remove debug writeline for key press

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/SelectionAdapter.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/SelectionAdapter.cs
@@ -43,7 +43,7 @@ namespace AutoCompleteTextBox.Editors
 
         public void HandleKeyDown(KeyEventArgs key)
         {
-            Debug.WriteLine(key.Key);
+            //Debug.WriteLine(key.Key);
             switch (key.Key)
             {
                 case Key.Down:


### PR DESCRIPTION
if you prefer I can add a static bool for if debugging should be enabled, but should cleanup debug messages in programs that use it.