### PR TITLE
When we handle keyboard or mouse events mark them as handled, closes #22

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteTextBox.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteTextBox.cs
@@ -282,6 +282,7 @@ namespace AutoCompleteTextBox.Editors
                 return;
             ItemsSelector.SelectedItem = ((FrameworkElement)e.OriginalSource)?.DataContext;
             OnSelectionAdapterCommit();
+            e.Handled = true;
         }
         private void AutoCompleteTextBox_GotFocus(object sender, RoutedEventArgs e)
         {

--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/SelectionAdapter.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/SelectionAdapter.cs
@@ -64,7 +64,10 @@ namespace AutoCompleteTextBox.Editors
                     Commit?.Invoke();
 
                     break;
+                default:
+                    return;
             }
+            key.Handled = true;
         }
 
         private void DecrementSelection()
@@ -98,6 +101,7 @@ namespace AutoCompleteTextBox.Editors
         private void OnSelectorMouseDown(object sender, MouseButtonEventArgs e)
         {
             Commit?.Invoke();
+            e.Handled = true;
         }
 
         #endregion


### PR DESCRIPTION
There is technically an up/down handler we don't do this on but some testing shows no negative effects.