### PR TITLE
Update Text SourceTrigger to match the users preference

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteComboBox.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteComboBox.cs
@@ -38,7 +38,7 @@ namespace AutoCompleteTextBox.Editors
         public static readonly DependencyProperty LoadingContentProperty = DependencyProperty.Register("LoadingContent", typeof(object), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(null));
         public static readonly DependencyProperty ProviderProperty = DependencyProperty.Register("Provider", typeof(IComboSuggestionProvider), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(null));
         public static readonly DependencyProperty SelectedItemProperty = DependencyProperty.Register("SelectedItem", typeof(object), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(null, OnSelectedItemChanged));
-        public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(string.Empty));
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(string.Empty, propertyChangedCallback: null, coerceValueCallback: null, isAnimationProhibited: false, defaultUpdateSourceTrigger: UpdateSourceTrigger.LostFocus, flags: FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
         public static readonly DependencyProperty FilterProperty = DependencyProperty.Register("Filter", typeof(string), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(string.Empty));
         public static readonly DependencyProperty MaxLengthProperty = DependencyProperty.Register("MaxLength", typeof(int), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(0));
         public static readonly DependencyProperty CharacterCasingProperty = DependencyProperty.Register("CharacterCasing", typeof(CharacterCasing), typeof(AutoCompleteComboBox), new FrameworkPropertyMetadata(CharacterCasing.Normal));
@@ -245,6 +245,43 @@ namespace AutoCompleteTextBox.Editors
                 listBox.ScrollIntoView(listBox.SelectedItem);
         }
 
+        public new BindingExpressionBase SetBinding(DependencyProperty dp, BindingBase binding){
+            var res = base.SetBinding(dp, binding);
+            CheckForParentTextBindingChange();
+            return res;
+        }
+        public new BindingExpressionBase SetBinding(DependencyProperty dp, String  path) {
+            var res = base.SetBinding(dp, path);
+            CheckForParentTextBindingChange();
+            return res;
+        }
+        public new void ClearValue(DependencyPropertyKey key) {
+            base.ClearValue(key);
+            CheckForParentTextBindingChange();
+        }
+        public new void ClearValue(DependencyProperty dp) {
+            base.ClearValue(dp);
+            CheckForParentTextBindingChange();
+        }
+        private void CheckForParentTextBindingChange(bool force=false) {
+            var CurrentBindingMode = BindingOperations.GetBinding(this, TextProperty)?.UpdateSourceTrigger ?? UpdateSourceTrigger.Default;
+            if (CurrentBindingMode != UpdateSourceTrigger.PropertyChanged)//preventing going any less frequent than property changed
+                CurrentBindingMode = UpdateSourceTrigger.Default;
+
+
+            if (CurrentBindingMode == CurrentTextboxTextBindingUpdateMode && force == false)
+                return;
+            var binding = new Binding {
+                Mode = BindingMode.TwoWay,
+                UpdateSourceTrigger = CurrentBindingMode,
+                Path = new PropertyPath(nameof(Text)),
+                RelativeSource = new RelativeSource(RelativeSourceMode.TemplatedParent),
+            };
+            CurrentTextboxTextBindingUpdateMode = CurrentBindingMode;
+            Editor?.SetBinding(TextBox.TextProperty, binding);
+        }
+
+        private UpdateSourceTrigger CurrentTextboxTextBindingUpdateMode;
 
         public override void OnApplyTemplate()
         {
@@ -262,6 +299,7 @@ namespace AutoCompleteTextBox.Editors
                 Editor.TextChanged += OnEditorTextChanged;
                 Editor.PreviewKeyDown += OnEditorKeyDown;
                 Editor.LostFocus += OnEditorLostFocus;
+                CheckForParentTextBindingChange(true);
 
                 if (SelectedItem != null)
                 {

--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/Themes/Generic.xaml
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/Themes/Generic.xaml
@@ -89,8 +89,7 @@
                                         CharacterCasing="{Binding Path=CharacterCasing, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}"
                                         Foreground="{Binding Path=Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWay}"
                                         MaxLength="{Binding Path=MaxLength, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}"
-                                        Style="{StaticResource ResourceKey=TransparentTextBoxStyle}"
-                                        Text="{Binding Path=Text, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}" />
+                                        Style="{StaticResource ResourceKey=TransparentTextBoxStyle}" />
                                 </Grid>
                             </DockPanel>
                             <Popup
@@ -187,8 +186,7 @@
                                         VerticalAlignment="Center"
                                         CharacterCasing="{Binding Path=CharacterCasing, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}"
                                         Focusable="True"
-                                        MaxLength="{Binding Path=MaxLength, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}"
-                                        Text="{Binding Path=Text, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}" />
+                                        MaxLength="{Binding Path=MaxLength, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=TwoWay}" />
                                 </DockPanel>
                             </Grid>
                         </DockPanel>


### PR DESCRIPTION
Closes #9 and Closes #30.

This also fixes the fact that we should probably mimic TextBox for the defaults for binding (two way and FocusLost).   Even though we were technically defaulting peoples binding of the AutoCompleteBox.Text to PropertyChanged because our internal binding to the textbox was FocusLost.

In terms of the debate in #9
Well I figured out the best solution was stop trying to figure out our best binding and just bind dynamically.  The issue with `UpdateSourceTrigger=PropertyChanged` was we were worried about the potential minor performance hit, if they did not also want PropertyChanged (as we were then calling our own update more than needed).

So to fix this we dynamically will create our binding in code rather than xaml.   In code we can easily query how our Text field is bound, and then match that update rate.   

Configuring it to match the users update rate was pretty straightforward.  The hard part was if they change what the actual binding is (so in code calling SetBinding for example).   The danger if we miss this, is we may not update the UpdateSourceTrigger if their new binding is different (minor detail).

So here is where we check if UpdateSourceTrigger changes:
	OnApplyTemplate  -  Catches any initial xaml binding
	control.SetBinding - Catches them directly calling SetBinding on the control
	control.ClearValue - Catches if they call it directly on the control, AND BindingOperations.ClearBinding calls it.


Here is what it misses:
`BindingOperations.SetBinding` - This does the same thing as control.SetBinding but sadly only calls SetValue on our control.

Now there are several other methods I looked at including:

For our binding setting NotifyOnTargetUpdated and NotifyOnSourceUpdated and hooking events: AutoCompleteTextBox.TargetUpdated AutoCompleteTextBox.SourceUpdated and on our Editor TextBox.TargetUpdated TextBox.SourceUpdated

the `AutoCompleteTextBox.Text` property set,  the dependency property backing `AutoCompleteTextBox.text` with it's property changed.

`AutoCompleteTextBox.SetValue` and `AutoCompleteTextBox.SetCurrentValue` (as BindingOperations.SetBinding call them)


The problem with most of these is they get called, but they also get called on every keystroke.  A few do not get called with every SetBinding call.  I looked at the arguments passed as well to see if I could find a difference there between SetBinding and the value itself changing, I could not.

I think this solution while not 100% coverage I think it is quite acceptable.  The worst case on both ends of the spectrum:

The user calls after loading `BindingOperations.SetBinding` to bind to the AutoCompleteTextBox.Text property with `UpdateSourceTrigger=PropertyChanged`.  This behavior won't be picked up until the next OnPaint, they would experience the current behavior until then.

The user at some point binds with `UpdateSourceTrigger=PropertyChanged` and we catch this change.   Later they call `BindingOperations.SetBinding` to set a new binding that uses `UpdateSourceTrigger=FocusLost`.  We don't catch this update until OnPaint, there is a very minor performance hit until then.

One minor note: I do not lower our binding rate below FocusLost (default), if they bind Explicit it is fine they will see that behavior we just continue to update as we do.