### PR TITLE
Provide a PreSelectionFinished event with the cause (Allows control of enter,tab,escape etc actions)

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/SelectionAdapter.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/SelectionAdapter.cs
@@ -6,6 +6,11 @@ namespace AutoCompleteTextBox.Editors
 {
     public class SelectionAdapter
     {
+        public class PreSelectionAdapterFinishArgs {
+            public EventCause cause;
+            public bool is_cancel;
+            public bool handled;
+        }
 
         #region "Fields"
         #endregion
@@ -22,9 +27,10 @@ namespace AutoCompleteTextBox.Editors
 
         #region "Events"
 
-        public delegate void CancelEventHandler();
+        public enum EventCause { Other, PopupClosed, ItemClicked, EnterPressed, EscapePressed, TabPressed, MouseDown}
+        public delegate void CancelEventHandler(EventCause cause);
 
-        public delegate void CommitEventHandler();
+        public delegate void CommitEventHandler(EventCause cause);
 
         public delegate void SelectionChangedEventHandler();
 
@@ -52,15 +58,15 @@ namespace AutoCompleteTextBox.Editors
                     DecrementSelection();
                     break;
                 case Key.Enter:
-                    Commit?.Invoke();
+                    Commit?.Invoke(EventCause.EnterPressed);
 
                     break;
                 case Key.Escape:
-                    Cancel?.Invoke();
+                    Cancel?.Invoke(EventCause.EscapePressed);
 
                     break;
                 case Key.Tab:
-                    Commit?.Invoke();
+                    Commit?.Invoke(EventCause.TabPressed);
 
                     break;
                 default:
@@ -104,7 +110,7 @@ namespace AutoCompleteTextBox.Editors
             // and list is scrolled up or down til the end.
             if (e.OriginalSource.GetType() != typeof(RepeatButton))
             {
-                Commit?.Invoke();
+                Commit?.Invoke(EventCause.MouseDown);
                 e.Handled = true;
             }
         }


### PR DESCRIPTION
This adds an event right before selection is finished allowing the user to decide if it should close or not and providing the cause for it finishing.  

It is also a bit of a backdoor event that lets you do some potentially-advantageous things.  Say, for example, you automatically want the first item of the available options selected when the user hits enter, as long as there is only one option and there is nothing currently selected.

```csharp
private void AutoCompleteTextBox_PreSelectionAdapterFinish(object sender, SelectionAdapter.PreSelectionAdapterFinishArgs e) {
			var box = sender as AutoCompleteComboBox;
			if (e.cause == SelectionAdapter.EventCause.EnterPressed) {
				if (box.ItemsSelector.SelectedItem == null && box.ItemsSelector.Items.Count == 1)
					box.ItemsSelector.SelectedItem = box.ItemsSelector.Items.GetItemAt(0);
			}
		}

```

You could also do it where any time the user hits enter it just takes the first option.

I stopped short of adding an option to the controls to specifically allow the user to control actions based on different causes.  Using the above style however you can accomplish whatever you want so is a bit more flexible (but less user intuitive than a full on helper).

I debated between having the event in AutoComplete*Box.cs and SelectionAdapter.  I went with the box itself for two reasons:

- The user can get the control from the sender (vs just the adapter)

- Sometimes the AutoComplete*Box.cs code calls cancel/commit so if just on a SelectionAdapter it wouldn't work for those calls.


Let me know if there are any specific changes desired (assuming merge plans).