### PR TITLE
Fix combobox from showing all results when should be filtered

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteComboBox.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteComboBox.cs
@@ -345,7 +345,8 @@ namespace AutoCompleteTextBox.Editors
             {
                 _suggestionsAdapter = new SuggestionsAdapter(this);
             }
-            _suggestionsAdapter.ShowFullCollection();
+            if (SelectedItem != null || String.IsNullOrWhiteSpace(Editor.Text))
+                _suggestionsAdapter.ShowFullCollection();
 
         }
 
@@ -534,7 +535,6 @@ namespace AutoCompleteTextBox.Editors
 
             public void GetSuggestions(string searchText)
             {
-                _filter = searchText;
                 _actb.IsLoading = true;
                 // Do not open drop down if control is not focused
                 if (_actb.IsKeyboardFocusWithin)
@@ -542,6 +542,7 @@ namespace AutoCompleteTextBox.Editors
                 _actb.ItemsSelector.ItemsSource = null;
                 ParameterizedThreadStart thInfo = GetSuggestionsAsync;
                 Thread th = new Thread(thInfo);
+                _filter = searchText;
                 th.Start(new object[] { searchText, _actb.Provider });
             }
             public void ShowFullCollection()


### PR DESCRIPTION
Closes #52, Closes #45, Closes #40

This should be reviewed to make sure the default behavior is still as expected, but I think it is preserved.

The first issue that happened was when a search occurred  and GetSuggestions was called it immediately set _filter = the search string, and then if the drop down was not opened, it opened it.  Opening the dropdown however causes ShowFullCollection() to also be called which then sets _filter = String.empty.    Even though GetSuggestionsAsync then ends up beign called after ShowFullCollection its results were invalidated as _filter is not set to the right value.    Moving _filter to try before the thread start fixes this issue.    This alone would fix #45.

This does not fully resolve the complete problem however, as there are times where the combo dropdown is expanded the user likely expects the results to be filtered and instead all results.  For example if the user has a filter string of someResultMatches clicks out of the combo box (causing expander to close) then clicks back in and hit down arrow on the keyboard or manually expands the expander, the entire collection is shown instead.

There are some times though that you want to see the entire collection even though there is text in the filter box.   This case I could see when the user has selected an item, the text is set to that item but if the user hits the dropdown arrow they likely want to see all results rather than just the one they just selected.

The change below to only call ShowFullCollection when there is empty text in the editor textbox or SelectedItem is null I think accomplishes both desired behaviors.  This fix likely means the move of _filter in GetSuggestions is not needed, but there may be program paths I can't think of in which that would still solve a bug (and I don't see any negative of it) so I left it in place.