### PR TITLE
Focus support improvements

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteTextBox.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteTextBox.cs
@@ -58,6 +58,7 @@ namespace AutoCompleteTextBox.Editors
         static AutoCompleteTextBox()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(AutoCompleteTextBox), new FrameworkPropertyMetadata(typeof(AutoCompleteTextBox)));
+            FocusableProperty.OverrideMetadata(typeof(AutoCompleteTextBox), new FrameworkPropertyMetadata(true));
         }
 
         #endregion
@@ -301,6 +302,7 @@ namespace AutoCompleteTextBox.Editors
             }
 
             GotFocus += AutoCompleteTextBox_GotFocus;
+            GotKeyboardFocus += AutoCompleteTextBox_GotKeyboardFocus;
 
             if (Popup != null)
             {
@@ -330,6 +332,13 @@ namespace AutoCompleteTextBox.Editors
         private void AutoCompleteTextBox_GotFocus(object sender, RoutedEventArgs e)
         {
             Editor?.Focus();
+        }
+        private void AutoCompleteTextBox_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e) {
+            if (e.NewFocus != this)
+                return;
+            if (e.OldFocus == Editor)
+                MoveFocus(new TraversalRequest(FocusNavigationDirection.Previous));
+
         }
 
         private string GetDisplayText(object dataItem)

--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/Themes/Generic.xaml
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/Themes/Generic.xaml
@@ -48,7 +48,6 @@
     </Style>
 
     <Style TargetType="{x:Type editors:AutoCompleteTextBox}">
-        <Setter Property="Focusable" Value="False" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="BorderBrush" Value="#FFABADB3" />
         <Setter Property="SuggestionBackground" Value="White" />


### PR DESCRIPTION
Given the textbox like nature of the control people might expect focus() calls to succeed.   This tweaks it to be focusable  (although moves is to the constructor as MS recommends, themes can still override).

Side effect to the current focus pattern (of forwarding focus to the textbox) causes the inability to shift+tab so this passes focus backwards as well.