### PR TITLE
Fix: ListBox not scrolling to selected item with PreviewSelection disabled

### DIFF
--- a/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteTextBox.cs
+++ b/AutoCompleteTextBox/AutoCompleteTextBox/Editors/AutoCompleteTextBox.cs
@@ -489,6 +489,8 @@ namespace AutoCompleteTextBox.Editors
 
         private void OnSelectionAdapterSelectionChanged()
         {
+            ScrollToSelectedItem();
+            
             if (!PreviewSelection)
                 return;
 
@@ -496,7 +498,6 @@ namespace AutoCompleteTextBox.Editors
             Editor.Text = ItemsSelector.SelectedItem == null ? Filter : GetDisplayText(ItemsSelector.SelectedItem);
             Editor.SelectionStart = Editor.Text.Length;
             Editor.SelectionLength = 0;
-            ScrollToSelectedItem();
             _isUpdatingText = false;
         }
 


### PR DESCRIPTION
This PR ensures that the suggestion selector scrolls to the highlighted item with the `PreviewSelection` flag disabled.